### PR TITLE
add configuration for custom pkg names

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ jobs:
         uses: guyarb/golang-test-annoations@v0.3.0
         with:
           test-results: test.json
+          package-name: foobar # optional, if using custom package name, github.com/owner/repo stripped from the pathname by default
 ```
 
 ## Development of this action

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const lineReader = require('line-by-line');
 
 try {
 	const testResultsPath = core.getInput('test-results');
+	const customPackageName = core.getInput('package-name');
 
 	var obj = new Object();
 	var lr = new lineReader(testResultsPath);
@@ -18,8 +19,12 @@ try {
 			return;
 		}
 		output = output.replace("\n", "%0A").replace("\r", "%0D")
-		// Removing the github.com/owner/reponame
+		// Strip github.com/owner/repo package from the path by default
 		var packageName = currentLine.Package.split("/").slice(3).join("/");
+		// If custom package is provided, strip custom package name from the path
+		if (customPackageName != null) {
+			packageName = currentLine.Package.replace(customPackageName + "/", "")
+		}
 		var newEntry = packageName + "/" + testName;
 		if (!obj.hasOwnProperty(newEntry)) {
 			obj[newEntry] = output;


### PR DESCRIPTION
When not using fully qualified url package names (eg `mod foobar` instead of `mod github.com/foo/bar`), the code that strips the package from the path strips too much of it.

This change leaves the default behavior unchanged (stripping `github.com/owner/repo`) and adds ability to configure custom package name to make path stripping work correctly with custom module names.