### PR TITLE
Add package-name input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,8 @@ inputs:
     description: 'The path of the go test results'
     required: true
     default: 'test.json'
+  package-name:
+    description: 'Package name override'
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
Fixes #8

I think it would be a slightly better option though to read the package name from the `go.mod` file (if any). Keeping `package-name` around for non-module packages can still make sense.