### PR TITLE
Test logging no longer affects retrieval of file name and line number

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10,6 +10,8 @@ const lineReader = __webpack_require__(631);
 const fs = __webpack_require__(747);
 
 try {
+	const regex = /(\s*[\w\d]+_test.go:\d+:)(.*?)(Test:\s+Test[\w\d]*?%0A)/gu; // Extracts only the failure from the logs (including whitespace)
+
 	const testResultsPath = core.getInput('test-results');
 	const customPackageName = core.getInput('package-name');
 
@@ -56,10 +58,13 @@ try {
 	lr.on('end', function() {
 		for (const [key, value] of Object.entries(obj)) {
 			if (value.includes("FAIL") && value.includes("_test.go")) {
-				const parts = value.split("%0A")[1].trim().split(":");
-				const file = key.split("/").slice(0, -1).join("/") + "/" + parts[0];
-				const lineNumber = parts[1];
-				core.info(`::error file=${file},line=${lineNumber}::${value}`)
+				var result;
+				while ((result = regex.exec(value)) !== null) {
+					const parts = result[0].split(":");
+					const file = key.split("/").slice(0, -1).join("/") + "/" + parts[0].trimStart();
+					const lineNumber = parts[1];
+					core.info(`::error file=${file},line=${lineNumber}::${result[0]}`);
+				}
 			}
 		}
 	});


### PR DESCRIPTION
Currently, if any logging is in the output of the test before the assert failure, the file name and line number is not detected properly causing GitHub to not be able to do the annotations. This change makes it so the assert failures are extracted (using regex), and then the file name and line number is extracted from that.

For example, a Go test with the following code on in `main_test.go` with the failure on line 18: 
```
func TestReproLog(t *testing.T) {
	log.Println("This is a test")
	require.True(t, false)
}
```
used to cause Github to receive the annotation text:
```
::error file=/2022/04/04 18,line=40::=== RUN   TestReproLog%0A2022/04/04 18:40:10 This is a test%0A    main_test.go:18: %0A        	Error Trace:	main_test.go:18%0A        	Error:      	Should be true%0A        	Test:       	TestReproLog%0A--- FAIL: TestReproLog (0.00s)%0A
```

and now it would receive: 
```
::error file=main_test.go,line=18::    main_test.go:18: %0A        	Error Trace:	main_test.go:18%0A        	Error:      	Should be true%0A        	Test:       	TestReproLog%0A
```

Example tests for this change can be seen here (along with tests that can be ran locally if needed using https://github.com/nektos/act): https://github.com/IsaacLambat/golang-test-annotations-testing

Example of annotations on a PR: https://github.com/IsaacLambat/golang-test-annotations-testing/pull/1/files