### PR TITLE
Add working-directory option & build command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,17 +1,21 @@
-name: 'Golang Test Annotations'
-description: 'Given a test output of go test, the failed tests will be annotated.'
+name: "Golang Test Annotations"
+description: "Given a test output of go test, the failed tests will be annotated."
 inputs:
-  test-results:  # Path of the test results
-    description: 'The path of the go test results'
+  test-results: # Path of the test results
+    description: "The path of the go test results"
     required: true
-    default: 'test.json'
+    default: "test.json"
   package-name:
     required: false
-    description: 'Package name override'
+    description: "Package name override"
+    default:
+  working-directory:
+    description: "The path of the go module"
+    required: false
     default:
 runs:
-  using: 'node16'
-  main: 'dist/index.js'
+  using: "node16"
+  main: "dist/index.js"
 branding:
   icon: "check"
   color: "green"

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 604:
+/***/ 351:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28,7 +28,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
 const os = __importStar(__nccwpck_require__(37));
-const utils_1 = __nccwpck_require__(245);
+const utils_1 = __nccwpck_require__(278);
 /**
  * Commands
  *
@@ -100,7 +100,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 127:
+/***/ 186:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -135,12 +135,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(604);
-const file_command_1 = __nccwpck_require__(352);
-const utils_1 = __nccwpck_require__(245);
+const command_1 = __nccwpck_require__(351);
+const file_command_1 = __nccwpck_require__(717);
+const utils_1 = __nccwpck_require__(278);
 const os = __importStar(__nccwpck_require__(37));
 const path = __importStar(__nccwpck_require__(17));
-const oidc_utils_1 = __nccwpck_require__(457);
+const oidc_utils_1 = __nccwpck_require__(41);
 /**
  * The code to exit an action
  */
@@ -419,7 +419,7 @@ exports.getIDToken = getIDToken;
 
 /***/ }),
 
-/***/ 352:
+/***/ 717:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -450,7 +450,7 @@ exports.issueCommand = void 0;
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(147));
 const os = __importStar(__nccwpck_require__(37));
-const utils_1 = __nccwpck_require__(245);
+const utils_1 = __nccwpck_require__(278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -468,7 +468,7 @@ exports.issueCommand = issueCommand;
 
 /***/ }),
 
-/***/ 457:
+/***/ 41:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -484,9 +484,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
-const http_client_1 = __nccwpck_require__(840);
-const auth_1 = __nccwpck_require__(421);
-const core_1 = __nccwpck_require__(127);
+const http_client_1 = __nccwpck_require__(925);
+const auth_1 = __nccwpck_require__(702);
+const core_1 = __nccwpck_require__(186);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -552,7 +552,7 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 245:
+/***/ 278:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -599,7 +599,7 @@ exports.toCommandProperties = toCommandProperties;
 
 /***/ }),
 
-/***/ 421:
+/***/ 702:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -665,7 +665,7 @@ exports.PersonalAccessTokenCredentialHandler = PersonalAccessTokenCredentialHand
 
 /***/ }),
 
-/***/ 840:
+/***/ 925:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -673,7 +673,7 @@ exports.PersonalAccessTokenCredentialHandler = PersonalAccessTokenCredentialHand
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const http = __nccwpck_require__(685);
 const https = __nccwpck_require__(687);
-const pm = __nccwpck_require__(45);
+const pm = __nccwpck_require__(443);
 let tunnel;
 var HttpCodes;
 (function (HttpCodes) {
@@ -1092,7 +1092,7 @@ class HttpClient {
         if (useProxy) {
             // If using proxy, need tunnel
             if (!tunnel) {
-                tunnel = __nccwpck_require__(265);
+                tunnel = __nccwpck_require__(294);
             }
             const agentOptions = {
                 maxSockets: maxSockets,
@@ -1210,7 +1210,7 @@ exports.HttpClient = HttpClient;
 
 /***/ }),
 
-/***/ 45:
+/***/ 443:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1275,7 +1275,7 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 631:
+/***/ 752:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 /*
@@ -1454,15 +1454,15 @@ module.exports = LineByLineReader;
 
 /***/ }),
 
-/***/ 265:
+/***/ 294:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(686);
+module.exports = __nccwpck_require__(219);
 
 
 /***/ }),
 
-/***/ 686:
+/***/ 219:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1871,8 +1871,8 @@ module.exports = require("util");
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
-const core = __nccwpck_require__(127);
-const lineReader = __nccwpck_require__(631);
+const core = __nccwpck_require__(186);
+const lineReader = __nccwpck_require__(752);
 const fs = __nccwpck_require__(147);
 
 
@@ -1881,6 +1881,7 @@ try {
 
 	const testResultsPath = core.getInput('test-results');
 	const customPackageName = core.getInput('package-name');
+	const workingDirectory = core.getInput('working-directory');
 
 	if (!fs.existsSync(testResultsPath)) {
 		core.warning(
@@ -1891,7 +1892,7 @@ try {
 
 	let obj = {};
 	let lr = new lineReader(testResultsPath);
-	lr.on('line', function(line) {
+	lr.on('line', function (line) {
 		const currentLine = JSON.parse(line);
 		const testName = currentLine.Test;
 		if (typeof testName === "undefined") {
@@ -1915,6 +1916,9 @@ try {
 				packageName = currentLine.Package.replace(customPackageName + "/", "")
 			}
 		}
+		if (workingDirectory !== "") {
+			packageName = workingDirectory + "/" + packageName
+		}
 		let newEntry = packageName + "/" + testName;
 		if (!obj.hasOwnProperty(newEntry)) {
 			obj[newEntry] = output;
@@ -1922,7 +1926,7 @@ try {
 			obj[newEntry] += output;
 		}
 	});
-	lr.on('end', function() {
+	lr.on('end', function () {
 		for (const [key, value] of Object.entries(obj)) {
 			if (value.includes("FAIL") && value.includes("_test.go")) {
 				var result;

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ try {
 
 	const testResultsPath = core.getInput('test-results');
 	const customPackageName = core.getInput('package-name');
+	const workingDirectory = core.getInput('working-directory');
 
 	if (!fs.existsSync(testResultsPath)) {
 		core.warning(
@@ -18,7 +19,7 @@ try {
 
 	let obj = {};
 	let lr = new lineReader(testResultsPath);
-	lr.on('line', function(line) {
+	lr.on('line', function (line) {
 		const currentLine = JSON.parse(line);
 		const testName = currentLine.Test;
 		if (typeof testName === "undefined") {
@@ -42,6 +43,9 @@ try {
 				packageName = currentLine.Package.replace(customPackageName + "/", "")
 			}
 		}
+		if (workingDirectory !== "") {
+			packageName = workingDirectory + "/" + packageName
+		}
 		let newEntry = packageName + "/" + testName;
 		if (!obj.hasOwnProperty(newEntry)) {
 			obj[newEntry] = output;
@@ -49,7 +53,7 @@ try {
 			obj[newEntry] += output;
 		}
 	});
-	lr.on('end', function() {
+	lr.on('end', function () {
 		for (const [key, value] of Object.entries(obj)) {
 			if (value.includes("FAIL") && value.includes("_test.go")) {
 				var result;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.6.0",
+        "@vercel/ncc": "^0.36.1",
         "line-by-line": "^0.1.6"
       }
     },
@@ -27,6 +28,14 @@
       "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
       "dependencies": {
         "tunnel": "0.0.6"
+      }
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
+      "integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==",
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
       }
     },
     "node_modules/line-by-line": {
@@ -62,6 +71,11 @@
       "requires": {
         "tunnel": "0.0.6"
       }
+    },
+    "@vercel/ncc": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
+      "integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw=="
     },
     "line-by-line": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "run": "node index.js",
+    "build": "ncc build index.js --license licenses.txt",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -20,6 +21,7 @@
   "homepage": "https://github.com/guyarb/golang-test-annoations#readme",
   "dependencies": {
     "@actions/core": "^1.6.0",
+    "@vercel/ncc": "^0.36.1",
     "line-by-line": "^0.1.6"
   }
 }


### PR DESCRIPTION
This PR does two things:

1. Add a build command with `npm run build` to generate the dist
2.  Add the `working-directory` input to deal with monorepos. This path serves as prefix for all go files. `main.go` => `<prefix>/main.go`