### PR TITLE
Update to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default:
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 branding:
   icon: "check"


### PR DESCRIPTION
Updated to node 20 in light of node 16 being deprecated. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/