### PR TITLE
[chore] Update to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default:
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"
 branding:
   icon: "check"


### PR DESCRIPTION
## Summary

- Switch `runs.using` from `node20` to `node24`

## Why

GitHub is deprecating Node 20 on Actions runners and recommends updating actions to Node 24.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/